### PR TITLE
Add LS with docker compose in the stack

### DIFF
--- a/.devcontainer/localstack/devcontainer.json
+++ b/.devcontainer/localstack/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "konductor-localstack",
     "remoteUser": "vscode",
-    "dockerFile": "Dockerfile",
+    // "dockerFile": "Dockerfile",
     "init": true,
     "privileged": true,
     "overrideCommand": false,
@@ -11,19 +11,21 @@
     "securityOpt": [
         "seccomp=unconfined"
     ],
-    "runArgs": [
-        "--network=host",
-        "--device=/dev/kvm"
-    ],
-    "mounts": [
-        "source=dind-var-lib-docker,target=/var/lib/docker,type=volume"
-    ],
+    // "runArgs": [
+    //     // "--network=host",
+    //     "--device=/dev/kvm"
+    // ],
+    // "mounts": [
+    //     "source=dind-var-lib-docker,target=/var/lib/docker,type=volume"
+    // ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
     "postCreateCommand": "devcontainer-links",
-    //"workspaceMount": "source=.,target=/home/vscode/konductor,type=bind,consistency=cached",
-    //"workspaceFolder": "/home/vscode/konductor",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "devcontainer",
+    // "workspaceMount": "source=.,target=/home/vscode/konductor,type=bind,consistency=cached",
+    "workspaceFolder": "/home/vscode/konductor",
     "forwardPorts": [
         1313,
         2222,

--- a/.devcontainer/localstack/docker-compose.yml
+++ b/.devcontainer/localstack/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.8"
+
+services:
+  devcontainer:
+    container_name: devcontainer
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/home/vscode/konductor:cached
+    command: sleep infinity
+    dns:
+      # Set the DNS server to be the LocalStack container
+      - 10.0.2.20
+    networks:
+      - ls
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
+    image: localstack/localstack-pro # required for Pro
+    ports:
+      - "127.0.0.1:4566:4566" # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559" # external services port range
+      - "127.0.0.1:443:443" # LocalStack HTTPS Gateway (Pro)
+    environment:
+      # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} # required for Pro
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      - DEBUG=${DEBUG:-0}
+      - PERSISTENCE=${PERSISTENCE:-0}
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      ls:
+        # Set the container IP address in the 10.0.2.0/24 subnet
+        ipv4_address: 10.0.2.20
+
+networks:
+  ls:
+    ipam:
+      config:
+        # Specify the subnet range for IP address allocation
+        - subnet: 10.0.2.0/24


### PR DESCRIPTION
# Motivation
We want to run LocalStack (LS) beside our Devcontainer. To do so we must set LS to function as a DNS server too not just our AWS API, this calls for separate management and a prior startup to our Devcontainer. After this is done, the default `localhost.localstack.cloud:4566` resolves in the LS container from the Devcontainer.

# Changes
- remove bits from devcontianer.json which call for the "simple Docker-way"
- add docker compose stack